### PR TITLE
Add Periscope

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,4 +24,5 @@ module.exports.registeredOrigins = {
     "booru.allthefallen.moe",
     "sakugabooru.com",
   ]),
+  "https://periscope.corsfix.com": new Set(["*"]),
 };


### PR DESCRIPTION
## Corsfix Open Source Sponsorship

## Website Details
- Website Name: Periscope
- Repository URL: https://github.com/reynaldichernando/periscope

## Description
Hosted version of ladder and alternative to 12ft.io.

### Allowed Origins
List allowed CORS origins:
- Origin 1: https://periscope.corsfix.com

### Allowed URLs
List all URLs that should be whitelisted:
- URL 1: *

## Additional Notes
Add any other context about the configuration here:

